### PR TITLE
Allow override of country data and change TW name

### DIFF
--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -5,7 +5,8 @@ import Browser exposing (UrlRequest(..))
 import Browser.Dom
 import Browser.Events
 import Browser.Navigation as Nav
-import Countries
+import Countries exposing (Country)
+import Dict exposing (Dict)
 import Element exposing (Element)
 import Element.Background
 import Element.Font
@@ -516,7 +517,19 @@ section windowSize text content =
 
 countries : List String
 countries =
-    List.map (\country -> country.name ++ " " ++ country.flag) Countries.all
+    let
+        overrides : Dict String Country
+        overrides =
+            Dict.fromList
+                [ ( "TW", { name = "Taiwan", code = "TW", flag = "🇹🇼" } ) ]
+    in
+    List.map
+        (\country ->
+            Dict.get country.code overrides
+                |> Maybe.withDefault country
+                |> (\{ name, flag } -> name ++ " " ++ flag)
+        )
+        Countries.all
 
 
 formView : Size -> Form -> Element FrontendMsg


### PR DESCRIPTION
Allow for easy customization of country data, specified by code (which shouldn't change).

Update Taiwan's name to the more neutral "Taiwan", instead of a more politically-charged option, e.g. "Taiwan, Province of China" or "Taiwan (ROC)".

Obviously feel free to add more modifications if you notice other issues or reject the PR entirely.